### PR TITLE
Fix test_read_cmake_files on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,6 +41,8 @@ def test_read_cmake_files(cmake_build):
         assert 'GNU' in api.get_variable_doc('CMAKE_CXX_COMPILER_ID')
     elif system == 'Windows':
         assert 'MSVC' in api.get_variable_doc('CMAKE_CXX_COMPILER_ID')
+    elif system == 'Darwin':
+        assert 'Clang' in api.get_variable_doc('CMAKE_CXX_COMPILER_ID')
     else:
         raise RuntimeError('Unexpected system')
 


### PR DESCRIPTION
Noticed this test was only set up for Linux/Windows. All tests passing for me on macOS now :)