### PR TITLE
Basic AST parsing and some starter diagnostics

### DIFF
--- a/src/cmake_language_server/diagnostics.py
+++ b/src/cmake_language_server/diagnostics.py
@@ -1,0 +1,94 @@
+from typing import Optional, List
+import pyparsing as pp
+from pygls.types import Diagnostic, DiagnosticSeverity, Range, Position
+
+
+class DiagnosticVisitor(object):
+    def __init__(self, liststr):
+        self.diagnostics = []
+        self.liststr = liststr
+
+    def visit(self, node):
+        visit_fn_name = "visit_" + type(node).__name__
+        if hasattr(self, visit_fn_name):
+            maybe_diagnostic = getattr(self, visit_fn_name)(node)
+            if maybe_diagnostic is not None:
+                self.diagnostics.append(maybe_diagnostic)
+
+    def loc_to_pos(self, loc):
+        return Position(pp.lineno(loc, self.liststr) - 1, pp.col(loc, self.liststr) - 1)
+
+    def loc_to_range(self, loc):
+        return Range(self.loc_to_pos(loc), self.loc_to_pos(loc + 1))
+
+
+class RedundantAssignment(DiagnosticVisitor):
+    def visit_CommandInvocation(self, node) -> Optional[Diagnostic]:
+        if node.identifier.lower() != "set":
+            return None
+
+        if len(node.arguments) != 2:
+            return None
+
+        lhs = node.arguments[0].value
+        rhs = node.arguments[1].value
+
+        # Refuse to diagnose expressions with multiple variable evaluations
+        if rhs.count("$") != 1:
+            return None
+
+        if lhs != rhs.strip("${}"):
+            return None
+
+        return Diagnostic(
+            range=self.loc_to_range(node.loc),
+            message="Redundant assignment: Destination and source variable names match",
+            source="cmake-ls",
+            severity=DiagnosticSeverity.Warning
+        )
+
+
+class ModernizeLowercaseCommands(DiagnosticVisitor):
+    def visit_CommandInvocation(self, node) -> Optional[Diagnostic]:
+        if not node.identifier.isupper():
+            return None
+
+        return Diagnostic(
+            range=self.loc_to_range(node.loc),
+            message="Modernize: prefer lowercase commands",
+            source="cmake-ls",
+            severity=DiagnosticSeverity.Information
+        )
+
+
+class ModernizePreferTargetCmds(DiagnosticVisitor):
+    dir_api = [
+        "add_definitions",
+        "add_compile_options",
+        "add_compile_definitions",
+        "include_directories",
+        "link_libraries"
+    ]
+    msg = "Modernize: prefer target-based commands over directory-based commands"
+
+    def visit_CommandInvocation(self, node) -> Optional[Diagnostic]:
+        if node.identifier.lower() not in ModernizePreferTargetCmds.dir_api:
+            return None
+
+        return Diagnostic(
+            range=self.loc_to_range(node.loc),
+            message=ModernizePreferTargetCmds.msg,
+            source="cmake-ls",
+            severity=DiagnosticSeverity.Information
+        )
+
+
+def diagnose(ast: pp.ParseResults, liststr: str) -> List[Diagnostic]:
+    diagnostics = []
+
+    for visitor_class in [RedundantAssignment, ModernizeLowercaseCommands, ModernizePreferTargetCmds]:
+        visitor = visitor_class(liststr)
+        ast[0].visit(visitor)
+        diagnostics.extend(visitor.diagnostics)
+
+    return diagnostics

--- a/src/cmake_language_server/diagnostics.py
+++ b/src/cmake_language_server/diagnostics.py
@@ -1,8 +1,10 @@
-from typing import Optional, List
-import pyparsing as pp
-from pygls.types import Diagnostic, DiagnosticSeverity, Range, Position
-from .grammar import ASTNode
 from itertools import combinations
+from typing import List, Optional
+
+import pyparsing as pp
+from pygls.types import Diagnostic, DiagnosticSeverity, Position, Range
+
+from .grammar import ASTNode
 
 
 class DiagnosticVisitor(object):
@@ -83,7 +85,8 @@ class ReturnInMacro(DiagnosticVisitor):
 
         return Diagnostic(
             range=self.loc_to_range(node.loc),
-            message="Return in macro: Prefer message(FATAL_ERROR ...) to halt execution in macro",
+            message="Return in macro: Prefer message(FATAL_ERROR ...) to halt "
+            "execution in macro",
             source="cmake-ls",
             severity=DiagnosticSeverity.Warning
         )
@@ -130,10 +133,13 @@ class DuplicateBranch(DiagnosticVisitor):
                 # Mark b a duplicate
                 return Diagnostic(
                     range=self.loc_to_range(b.loc),
-                    message="Duplicate conditional branch: Condition matches a previous branch",
+                    message="Duplicate conditional branch: "
+                    "Condition matches a previous branch",
                     source="cmake-ls",
                     severity=DiagnosticSeverity.Warning
                 )
+
+        return None
 
 
 class ModernizeLowercaseCommands(DiagnosticVisitor):
@@ -179,7 +185,7 @@ class ModernizePreferTargetCmds(DiagnosticVisitor):
 
 
 def diagnose(ast: pp.ParseResults, liststr: str) -> List[Diagnostic]:
-    diagnostics = []
+    diagnostics: List[Diagnostic] = []
 
     visitors = [
         DuplicateBranch,

--- a/src/cmake_language_server/formatter.py
+++ b/src/cmake_language_server/formatter.py
@@ -4,7 +4,7 @@ from .parser import TokenList
 
 
 class Formatter(object):
-    indnt: str
+    indent: str
     lower_identifier: bool
 
     def __init__(self, indent="  ", lower_identifier=True):
@@ -13,7 +13,7 @@ class Formatter(object):
 
     def format(self, tokens: TokenList) -> str:
         cmds: List[str] = [""]
-        indnet_level = 0
+        indent_level = 0
         for token in tokens:
             if isinstance(token, tuple):
                 raw_identifier = token[0]
@@ -27,9 +27,9 @@ class Formatter(object):
                     "endmacro",
                     "endfunction",
                 ):
-                    if indnet_level > 0:
-                        indnet_level -= 1
-                cmds[-1] = self.indent * indnet_level
+                    if indent_level > 0:
+                        indent_level -= 1
+                cmds[-1] = self.indent * indent_level
                 cmds[-1] += identifier if self.lower_identifier else raw_identifier
                 args = self._format_args(token[1])
                 if len(args) < 2:
@@ -37,8 +37,8 @@ class Formatter(object):
                 else:
                     cmds[-1] += "(\n"
                     for arg in args:
-                        cmds[-1] += self.indent * (indnet_level + 1) + arg + "\n"
-                    cmds[-1] += self.indent * indnet_level + ")"
+                        cmds[-1] += self.indent * (indent_level + 1) + arg + "\n"
+                    cmds[-1] += self.indent * indent_level + ")"
                 if identifier in (
                     "if",
                     "elseif",
@@ -48,14 +48,14 @@ class Formatter(object):
                     "macro",
                     "function",
                 ):
-                    indnet_level += 1
+                    indent_level += 1
             elif token == "\n":
                 cmds.append("")
             elif token[0] == "#":
                 if cmds[-1]:
                     cmds[-1] += token
                 else:
-                    cmds[-1] = self.indent * indnet_level + token
+                    cmds[-1] = self.indent * indent_level + token
             elif cmds[-1]:
                 cmds[-1] += token
 
@@ -101,7 +101,7 @@ def main(args: List[str] = None):
     from pathlib import Path
 
     from . import __version__
-    from .parser import ListParser
+    from .parser import CMakeListsParser
 
     parser = ArgumentParser(
         description="Format CMake list files.",
@@ -125,7 +125,7 @@ def main(args: List[str] = None):
     if not args.lists:
         args.lists.append(None)
 
-    list_parser = ListParser()
+    list_parser = CMakeListsParser()
     formatter = Formatter()
     for listpath in args.lists:
         if listpath is None:
@@ -134,7 +134,7 @@ def main(args: List[str] = None):
         else:
             with listpath.open() as fp:
                 content = fp.read()
-        tokens, remain = list_parser.parse(content)
+        tokens, remain = list_parser.parse_tokens(content)
         formatted = content if remain else formatter.format(tokens)
 
         if args.inplace:

--- a/src/cmake_language_server/grammar.py
+++ b/src/cmake_language_server/grammar.py
@@ -1,0 +1,164 @@
+import pyparsing as pp
+
+
+class ASTNode(object):
+    def __init__(self, loc, tokens):
+        self.loc = loc
+        self.tokens = tokens
+        self.assign_fields()
+
+    def __str__(self):
+        return self.__class__.__name__ + ':' + str(self.__dict__)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class ListsFile(ASTNode):
+    def assign_fields(self):
+        self.invocations = self.tokens.asList()
+        del self.tokens
+
+    def visit(self, visitor):
+        visitor.visit(self)
+        for child in self.invocations:
+            child.visit(visitor)
+
+
+class CommandInvocation(ASTNode):
+    def assign_fields(self):
+        self.identifier = self.tokens[0]
+        self.arguments = self.tokens[1].asList()
+        del self.tokens
+
+    def visit(self, visitor):
+        visitor.visit(self)
+        for child in self.arguments:
+            child.visit(visitor)
+
+
+class QuotedArgument(ASTNode):
+    def assign_fields(self):
+        self.value = self.tokens[0]
+        del self.tokens
+
+    def visit(self, visitor):
+        visitor.visit(self)
+
+
+class UnquotedArgument(ASTNode):
+    def assign_fields(self):
+        self.value = self.tokens[0]
+        del self.tokens
+
+    def visit(self, visitor):
+        visitor.visit(self)
+
+
+class BracketArgument(ASTNode):
+    def assign_fields(self):
+        self.value = self.tokens[0]
+        del self.tokens
+
+    def visit(self, visitor):
+        visitor.visit(self)
+
+
+def cmake_grammar(generate_ast: bool) -> pp.ParserElement:
+    """ Defines the cmake grammar and semantic actions to generate an AST """
+    # Spaces and new lines
+    newline = "\n"
+    space_plus = pp.Regex("[ \t]+")
+    space_star = pp.Optional(space_plus)
+
+    # Quoted arguments
+    quoted_element = pp.Regex(r'[^\\"]|\\[^A-Za-z0-9]|\\[trn]')
+    if generate_ast:
+        quoted_argument = pp.Combine(
+            pp.Suppress('"')
+            + pp.ZeroOrMore(quoted_element)
+            + pp.Suppress('"')
+        ).setParseAction(QuotedArgument)
+    else:
+        quoted_argument = pp.Combine('"' + pp.ZeroOrMore(quoted_element) + '"')
+
+    # Bracket content
+    bracket_content = pp.Forward()
+
+    def action_bracket_open(tokens: pp.ParseResults):
+        nonlocal bracket_content
+        marker = "]" + "=" * (len(tokens[0]) - 2) + "]"
+        bracket_content <<= pp.SkipTo(marker, include=True)
+
+    bracket_open = pp.Regex(r"\[=*\[").setParseAction(action_bracket_open)
+    bracket_argument = pp.Combine(bracket_open + bracket_content)
+    if generate_ast:
+        bracket_argument = bracket_argument.setParseAction(BracketArgument)
+
+    # Unquoted arguments
+    unquoted_element = pp.Regex(r'[^\s()#"\\]|\\[^A-Za-z0-9]|\\[trn]')
+    unquoted_argument = pp.Combine(pp.OneOrMore(unquoted_element))
+    if generate_ast:
+        unquoted_argument = unquoted_argument.setParseAction(UnquotedArgument)
+
+    argument = bracket_argument | quoted_argument | unquoted_argument
+
+    # Comments
+    line_comment = pp.Combine("#" + ~bracket_open + pp.SkipTo(pp.LineEnd()))
+    bracket_comment = pp.Combine("#" + bracket_argument)
+    line_ending = (
+        space_star
+        + pp.ZeroOrMore(bracket_comment + space_star)
+        + pp.Optional(line_comment)
+        + (newline | pp.lineEnd)
+    )
+
+    # Command invocation
+    identifier = pp.Word(pp.alphas + "_", pp.alphanums + "_")
+    arguments = pp.Forward()
+    if generate_ast:
+        arguments << pp.ZeroOrMore(
+            argument
+            | line_ending.suppress()
+            | space_plus.suppress()
+            | pp.Suppress("(") + arguments + pp.Suppress(")")
+        ).leaveWhitespace()
+    else:
+        arguments << pp.ZeroOrMore(
+            argument | line_ending | space_plus | "(" + arguments + ")"
+        ).leaveWhitespace()
+
+    arguments = pp.Group(arguments)
+    PAREN_L, PAREN_R = map(pp.Suppress, "()")
+    command_invocation = (
+        identifier + space_star.suppress() + PAREN_L + arguments + PAREN_R
+    )
+    if generate_ast:
+        command_invocation = command_invocation.setParseAction(CommandInvocation)
+    else:
+        command_invocation = command_invocation.setParseAction(
+            lambda t: (t[0], t[1].asList()))
+
+    # Superstructure
+    if generate_ast:
+        file_element = (
+            space_star.suppress() + command_invocation + line_ending.suppress()
+            | line_ending.suppress()
+        ).leaveWhitespace()
+    else:
+        file_element = (
+            space_star + command_invocation + line_ending | line_ending
+        ).leaveWhitespace()
+
+    listsfile = pp.ZeroOrMore(file_element)
+    if generate_ast:
+        listsfile.setParseAction(ListsFile)
+
+    # Assign expression names for rr diagram and better explanations
+    var_name = None
+    for var_name in locals().keys():
+        if isinstance(locals()[var_name], pp.ParserElement):
+            locals()[var_name].setName(var_name)
+            # locals()[var_name].setDebug()
+
+    return listsfile

--- a/src/cmake_language_server/grammar.py
+++ b/src/cmake_language_server/grammar.py
@@ -1,3 +1,4 @@
+from typing import List, Any
 import pyparsing as pp
 
 
@@ -13,59 +14,164 @@ class ASTNode(object):
     def __repr__(self):
         return self.__str__()
 
-
-class ListsFile(ASTNode):
-    def assign_fields(self):
-        self.invocations = self.tokens.asList()
-        del self.tokens
-
     def visit(self, visitor):
         visitor.visit(self)
-        for child in self.invocations:
+
+    def visit_self_and_children(self, visitor, children):
+        visitor.visit(self)
+        for child in children:
             child.visit(visitor)
 
 
+class Argument(ASTNode):
+    value: str  # NOTE: Without parsed quotes or bracket!
+
+    def assign_fields(self):
+        self.value = self.tokens[0]
+        del self.tokens
+
+
+class UnquotedArgument(Argument):
+    pass
+
+
+class QuotedArgument(Argument):
+    pass
+
+
+class BracketArgument(Argument):
+    pass
+
+
 class CommandInvocation(ASTNode):
+    identifier: str
+    arguments: List[Argument]
+
     def assign_fields(self):
         self.identifier = self.tokens[0]
         self.arguments = self.tokens[1].asList()
         del self.tokens
 
     def visit(self, visitor):
+        self.visit_self_and_children(visitor, self.arguments)
+
+
+class CommandDeclarationStart(CommandInvocation):
+    identifier: str  # Some case of the keyword function or macro
+    name: Argument  # Name of the command being declared
+    arguments: List[Argument]  # Arguments to the command being declared
+
+    def assign_fields(self):
+        self.identifier = self.tokens[0]
+        self.name = self.tokens[1][0]
+        self.arguments = self.tokens[1][1:]
+        del self.tokens
+
+    def visit(self, visitor):
         visitor.visit(self)
+        self.name.visit(visitor)
         for child in self.arguments:
             child.visit(visitor)
 
 
-class QuotedArgument(ASTNode):
+class CommandDeclarationEnd(CommandInvocation):
+    pass
+
+
+class CommandDeclarationBlock(ASTNode):
+    declaration: CommandDeclarationStart
+    children: List[Any]
+    end: CommandDeclarationEnd
+
     def assign_fields(self):
-        self.value = self.tokens[0]
+        self.declaration = self.tokens[0]
+        self.end = self.tokens[-1]
+        self.children = self.tokens[1:-1]
+        del self.tokens
+
+    def visit(self, visitor):
+        self.visit_self_and_children(visitor, self.children)
+
+
+class ConditionalBranchDeclaration(CommandInvocation):
+    pass
+
+
+class ConditionalEnd(CommandInvocation):
+    pass
+
+
+class ConditionalBranch(ASTNode):
+    declaration: ConditionalBranchDeclaration
+    children: List[Any]
+
+    def assign_fields(self):
+        self.declaration = self.tokens[0]
+        self.children = self.tokens[1:]
+        del self.tokens
+
+    def visit(self, visitor):
+        self.visit_self_and_children(visitor, self.children)
+
+
+class ConditionalBlock(ASTNode):
+    branches: List[ConditionalBranch]
+    end: ConditionalEnd
+
+    def assign_fields(self):
+        self.branches = self.tokens[:-1]
+        self.end = self.tokens[-1]
         del self.tokens
 
     def visit(self, visitor):
         visitor.visit(self)
+        for child in self.branches:
+            child.visit(visitor)
+
+        self.end.visit(visitor)
 
 
-class UnquotedArgument(ASTNode):
+class LoopDeclaration(CommandInvocation):
+    pass
+
+
+class LoopEnd(CommandInvocation):
+    pass
+
+
+class LoopBlock(ASTNode):
+    declaration: LoopDeclaration
+    children: List[Any]
+    end: LoopEnd
+
     def assign_fields(self):
-        self.value = self.tokens[0]
+        self.declaration = self.tokens[0]
+        self.children = self.tokens[1:-1]
+        self.end = self.tokens[-1]
         del self.tokens
 
     def visit(self, visitor):
         visitor.visit(self)
+        self.declaration.visit(visitor)
+        for child in self.children:
+            child.visit(visitor)
+
+        self.end.visit(visitor)
 
 
-class BracketArgument(ASTNode):
+class ListsFile(ASTNode):
+    blocks: List[Any]
+
     def assign_fields(self):
-        self.value = self.tokens[0]
+        self.blocks = self.tokens.asList()
         del self.tokens
 
     def visit(self, visitor):
-        visitor.visit(self)
+        self.visit_self_and_children(visitor, self.blocks)
 
 
-def cmake_grammar(generate_ast: bool) -> pp.ParserElement:
-    """ Defines the cmake grammar and semantic actions to generate an AST """
+def token_grammar() -> pp.ParserElement:
+    """ Defines a cmake grammar to generate formattable tokens """
     # Spaces and new lines
     newline = "\n"
     space_plus = pp.Regex("[ \t]+")
@@ -73,14 +179,7 @@ def cmake_grammar(generate_ast: bool) -> pp.ParserElement:
 
     # Quoted arguments
     quoted_element = pp.Regex(r'[^\\"]|\\[^A-Za-z0-9]|\\[trn]')
-    if generate_ast:
-        quoted_argument = pp.Combine(
-            pp.Suppress('"')
-            + pp.ZeroOrMore(quoted_element)
-            + pp.Suppress('"')
-        ).setParseAction(QuotedArgument)
-    else:
-        quoted_argument = pp.Combine('"' + pp.ZeroOrMore(quoted_element) + '"')
+    quoted_argument = pp.Combine('"' + pp.ZeroOrMore(quoted_element) + '"')
 
     # Bracket content
     bracket_content = pp.Forward()
@@ -92,14 +191,10 @@ def cmake_grammar(generate_ast: bool) -> pp.ParserElement:
 
     bracket_open = pp.Regex(r"\[=*\[").setParseAction(action_bracket_open)
     bracket_argument = pp.Combine(bracket_open + bracket_content)
-    if generate_ast:
-        bracket_argument = bracket_argument.setParseAction(BracketArgument)
 
     # Unquoted arguments
     unquoted_element = pp.Regex(r'[^\s()#"\\]|\\[^A-Za-z0-9]|\\[trn]')
     unquoted_argument = pp.Combine(pp.OneOrMore(unquoted_element))
-    if generate_ast:
-        unquoted_argument = unquoted_argument.setParseAction(UnquotedArgument)
 
     argument = bracket_argument | quoted_argument | unquoted_argument
 
@@ -116,43 +211,152 @@ def cmake_grammar(generate_ast: bool) -> pp.ParserElement:
     # Command invocation
     identifier = pp.Word(pp.alphas + "_", pp.alphanums + "_")
     arguments = pp.Forward()
-    if generate_ast:
-        arguments << pp.ZeroOrMore(
-            argument
-            | line_ending.suppress()
-            | space_plus.suppress()
-            | pp.Suppress("(") + arguments + pp.Suppress(")")
-        ).leaveWhitespace()
-    else:
-        arguments << pp.ZeroOrMore(
-            argument | line_ending | space_plus | "(" + arguments + ")"
-        ).leaveWhitespace()
+    arguments << pp.ZeroOrMore(
+        argument | line_ending | space_plus | "(" + arguments + ")"
+    ).leaveWhitespace()
 
     arguments = pp.Group(arguments)
     PAREN_L, PAREN_R = map(pp.Suppress, "()")
     command_invocation = (
         identifier + space_star.suppress() + PAREN_L + arguments + PAREN_R
     )
-    if generate_ast:
-        command_invocation = command_invocation.setParseAction(CommandInvocation)
-    else:
-        command_invocation = command_invocation.setParseAction(
-            lambda t: (t[0], t[1].asList()))
+    command_invocation = command_invocation.setParseAction(
+        lambda t: (t[0], t[1].asList()))
 
     # Superstructure
-    if generate_ast:
-        file_element = (
-            space_star.suppress() + command_invocation + line_ending.suppress()
-            | line_ending.suppress()
-        ).leaveWhitespace()
-    else:
-        file_element = (
-            space_star + command_invocation + line_ending | line_ending
-        ).leaveWhitespace()
-
+    file_element = (
+        space_star + command_invocation + line_ending | line_ending
+    ).leaveWhitespace()
     listsfile = pp.ZeroOrMore(file_element)
-    if generate_ast:
-        listsfile.setParseAction(ListsFile)
+
+    return listsfile
+
+
+def ast_grammar() -> pp.ParserElement:
+    """ Defines a cmake grammar and semantic actions to generate an AST """
+    # Spaces and new lines
+    newline = "\n"
+    space_plus = pp.Regex("[ \t]+")
+    space_star = pp.Optional(space_plus)
+
+    # Quoted arguments
+    quoted_element = pp.Regex(r'[^\\"]|\\[^A-Za-z0-9]|\\[trn]')
+    quoted_argument = pp.Combine(
+        pp.Suppress('"')
+        + pp.ZeroOrMore(quoted_element)
+        + pp.Suppress('"')
+    ).setParseAction(QuotedArgument)
+
+    # Bracket content
+    bracket_content = pp.Forward()
+
+    def action_bracket_open(tokens: pp.ParseResults):
+        nonlocal bracket_content
+        marker = "]" + "=" * (len(tokens[0]) - 2) + "]"
+        bracket_content <<= pp.SkipTo(marker, include=True)
+
+    bracket_open = pp.Regex(r"\[=*\[").setParseAction(action_bracket_open)
+    bracket_argument = (bracket_open.suppress() +
+                        bracket_content).setParseAction(BracketArgument)
+
+    # Unquoted arguments
+    unquoted_element = pp.Regex(r'[^\s()#"\\]|\\[^A-Za-z0-9]|\\[trn]')
+    unquoted_argument = pp.Combine(pp.OneOrMore(
+        unquoted_element)).setParseAction(UnquotedArgument)
+
+    argument = bracket_argument | quoted_argument | unquoted_argument
+
+    # Comments
+    line_comment = pp.Combine("#" + ~bracket_open + pp.SkipTo(pp.LineEnd()))
+    bracket_comment = pp.Combine("#" + bracket_argument)
+    line_ending = (
+        space_star
+        + pp.ZeroOrMore(bracket_comment + space_star)
+        + pp.Optional(line_comment)
+        + (newline | pp.lineEnd)
+    )
+
+    # Command invocation
+    block_keyword_strs = [
+        "function", "macro", "endfunction", "endmacro",
+        "if", "elseif", "endif",
+        "foreach", "endforeach", "while", "endwhile"
+    ]
+    block_keywords = pp.Or([pp.CaselessLiteral(lit) for lit in block_keyword_strs])
+    identifier = ~block_keywords + pp.Word(pp.alphas + "_", pp.alphanums + "_")
+    arguments = pp.Forward()
+    arguments << pp.ZeroOrMore(
+        argument
+        | line_ending.suppress()
+        | space_plus.suppress()
+        | pp.Suppress("(") + arguments + pp.Suppress(")")
+    ).leaveWhitespace()
+
+    arguments = pp.Group(arguments)
+    PAREN_L, PAREN_R = map(pp.Suppress, "()")
+    command_invocation = (
+        identifier + space_star.suppress() + PAREN_L + arguments + PAREN_R
+    ).setParseAction(CommandInvocation)
+
+    # Superstructure
+    block = pp.Forward()
+
+    def make_line_parser(invocation):
+        return space_star.suppress() + invocation + line_ending.suppress()
+
+    def make_keyword_parser(literal_parser, action):
+        return (
+            literal_parser + space_star.suppress() + PAREN_L + arguments + PAREN_R
+        ).setParseAction(action)
+
+    def make_keyword_line_parser(literal, action):
+        # parser = pp.Regex(pattern=literal, flags=re.IGNORECASE)
+        parser = pp.CaselessLiteral(literal)
+        kw_parser = make_keyword_parser(parser, action)
+        return make_line_parser(kw_parser)
+
+    # Command declaration (function and macro)
+    function_decl_start = make_keyword_line_parser("function", CommandDeclarationStart)
+    function_decl_end = make_keyword_line_parser("endfunction", CommandDeclarationEnd)
+    macro_decl_start = make_keyword_line_parser("macro", CommandDeclarationStart)
+    macro_decl_end = make_keyword_line_parser("endmacro", CommandDeclarationEnd)
+    command_decl_block = (
+        (function_decl_start - pp.ZeroOrMore(block) - function_decl_end)
+        | (macro_decl_start - pp.ZeroOrMore(block) - macro_decl_end)
+    ).setParseAction(CommandDeclarationBlock)
+
+    # Conditional block
+    if_line = make_keyword_line_parser("if", ConditionalBranchDeclaration)
+    elseif_line = make_keyword_line_parser("elseif", ConditionalBranchDeclaration)
+    endif_line = make_keyword_line_parser("endif", ConditionalEnd)
+    conditional_block = (
+        (if_line - pp.ZeroOrMore(block)).setParseAction(ConditionalBranch)
+        - pp.ZeroOrMore(
+            (elseif_line - pp.ZeroOrMore(block)).setParseAction(ConditionalBranch)
+        )
+        - endif_line
+    ).setParseAction(ConditionalBlock)
+
+    # Loops
+    foreach_start = make_keyword_line_parser("foreach", LoopDeclaration)
+    foreach_end = make_keyword_line_parser("endforeach", LoopEnd)
+    while_start = make_keyword_line_parser("while", LoopDeclaration)
+    while_end = make_keyword_line_parser("endwhile", LoopEnd)
+    loop_block = (
+        (foreach_start - pp.ZeroOrMore(block) - foreach_end)
+        | (while_end - pp.ZeroOrMore(block) - while_end)
+    ).setParseAction(LoopBlock)
+
+    # Now we can define block
+    block <<= (
+        command_decl_block
+        | conditional_block
+        | loop_block
+        | space_star.suppress() + command_invocation + line_ending.suppress()
+        | line_ending.suppress()
+    ).leaveWhitespace()
+
+    listsfile = pp.ZeroOrMore(block).setParseAction(ListsFile)
 
     # Assign expression names for rr diagram and better explanations
     var_name = None

--- a/src/cmake_language_server/grammar.py
+++ b/src/cmake_language_server/grammar.py
@@ -1,4 +1,5 @@
-from typing import List, Any
+from typing import Any, List
+
 import pyparsing as pp
 
 

--- a/src/cmake_language_server/parser.py
+++ b/src/cmake_language_server/parser.py
@@ -1,7 +1,9 @@
 from typing import List, Tuple, Union
+
 import pyparsing as pp
+from pygls.types import Diagnostic, DiagnosticSeverity, Position, Range
+
 from .grammar import ast_grammar, token_grammar
-from pygls.types import Diagnostic, DiagnosticSeverity, Range, Position
 
 CommandTokenType = Tuple[str, List[str]]
 TokenType = Union[str, CommandTokenType]

--- a/src/cmake_language_server/parser.py
+++ b/src/cmake_language_server/parser.py
@@ -1,67 +1,31 @@
 from typing import List, Tuple, Union
-
 import pyparsing as pp
+from .grammar import cmake_grammar
 
 CommandTokenType = Tuple[str, List[str]]
 TokenType = Union[str, CommandTokenType]
 TokenList = List[TokenType]
 
 
-class ListParser(object):
-    _parser: pp.ParserElement
+class CMakeListsParser(object):
+    token_parser: pp.ParserElement
+    ast_parser: pp.ParserElement
 
     def __init__(self):
-        newline = "\n"
-        space_plus = pp.Regex("[ \t]+")
-        space_star = pp.Optional(space_plus)
+        self.token_parser = cmake_grammar(generate_ast=False)
+        self.ast_parser = cmake_grammar(generate_ast=True)
 
-        quoted_element = pp.Regex(r'[^\\"]|\\[^A-Za-z0-9]|\\[trn]')
-        quoted_argument = pp.Combine('"' + pp.ZeroOrMore(quoted_element) + '"')
-
-        bracket_content = pp.Forward()
-
-        def action_bracket_open(tokens: pp.ParseResults):
-            nonlocal bracket_content
-            marker = "]" + "=" * (len(tokens[0]) - 2) + "]"
-            bracket_content <<= pp.SkipTo(marker, include=True)
-
-        bracket_open = pp.Regex(r"\[=*\[").setParseAction(action_bracket_open)
-        bracket_argument = pp.Combine(bracket_open + bracket_content)
-
-        unquoted_element = pp.Regex(r'[^\s()#"\\]|\\[^A-Za-z0-9]|\\[trn]')
-        unquoted_argument = pp.Combine(pp.OneOrMore(unquoted_element))
-
-        argument = bracket_argument | quoted_argument | unquoted_argument
-
-        line_comment = pp.Combine("#" + ~bracket_open + pp.SkipTo(pp.LineEnd()))
-        bracket_comment = pp.Combine("#" + bracket_argument)
-        line_ending = (
-            space_star
-            + pp.ZeroOrMore(bracket_comment + space_star)
-            + pp.Optional(line_comment)
-            + (newline | pp.lineEnd)
-        )
-
-        identifier = pp.Word(pp.alphas + "_", pp.alphanums + "_")
-        arguments = pp.Forward()
-        arguments << pp.ZeroOrMore(
-            argument | line_ending | space_plus | "(" + arguments + ")"
-        ).leaveWhitespace()
-        arguments = pp.Group(arguments)
-        PAREN_L, PAREN_R = map(pp.Suppress, "()")
-        command_invocation = (
-            identifier + space_star.suppress() + PAREN_L + arguments + PAREN_R
-        ).setParseAction(lambda t: (t[0], t[1].asList()))
-
-        file_element = (
-            space_star + command_invocation + line_ending | line_ending
-        ).leaveWhitespace()
-        file = pp.ZeroOrMore(file_element)
-
-        self._parser = file
-
-    def parse(self, liststr: str) -> Tuple[TokenList, str]:
-        for t, s, e in self._parser.scanString(liststr, maxMatches=1):
+    def parse_tokens(self, liststr: str) -> Tuple[TokenList, str]:
+        """ Parse a CMakeLists file into tokens """
+        for t, s, e in self.token_parser.scanString(liststr, maxMatches=1):
             if s == 0:
                 return t.asList(), liststr[e:]
         return [], liststr
+
+    def parse_ast(self, liststr: str) -> Tuple[pp.ParseResults, str]:
+        """ Parse a CMakeLists file into an AST """
+        for t, s, e in self.ast_parser.scanString(liststr, maxMatches=1):
+            if s == 0:
+                return t, liststr[e:]
+
+        return pp.ParseResults(), liststr

--- a/src/cmake_language_server/parser.py
+++ b/src/cmake_language_server/parser.py
@@ -1,6 +1,7 @@
 from typing import List, Tuple, Union
 import pyparsing as pp
-from .grammar import cmake_grammar
+from .grammar import ast_grammar, token_grammar
+from pygls.types import Diagnostic, DiagnosticSeverity, Range, Position
 
 CommandTokenType = Tuple[str, List[str]]
 TokenType = Union[str, CommandTokenType]
@@ -12,8 +13,8 @@ class CMakeListsParser(object):
     ast_parser: pp.ParserElement
 
     def __init__(self):
-        self.token_parser = cmake_grammar(generate_ast=False)
-        self.ast_parser = cmake_grammar(generate_ast=True)
+        self.token_parser = token_grammar()
+        self.ast_parser = ast_grammar()
 
     def parse_tokens(self, liststr: str) -> Tuple[TokenList, str]:
         """ Parse a CMakeLists file into tokens """
@@ -22,10 +23,52 @@ class CMakeListsParser(object):
                 return t.asList(), liststr[e:]
         return [], liststr
 
-    def parse_ast(self, liststr: str) -> Tuple[pp.ParseResults, str]:
-        """ Parse a CMakeLists file into an AST """
-        for t, s, e in self.ast_parser.scanString(liststr, maxMatches=1):
-            if s == 0:
-                return t, liststr[e:]
+    def parse_ast(self, liststr: str) -> Union[Tuple[pp.ParseResults, str], Diagnostic]:
+        """ Parse a CMakeLists file into an AST or make a Diagnostic if parsing fails"""
+        try:
+            for t, s, e in self.ast_parser.scanString(liststr, maxMatches=1):
+                if s == 0:
+                    return t, liststr[e:]
 
-        return pp.ParseResults(), liststr
+            return pp.ParseResults(), liststr
+
+        except pp.ParseSyntaxException as pe:
+            # Convert parsing exception into a diagnostic
+            start = Position(max(0, pe.lineno-2), max(0, pe.col-1))
+            end = Position(max(0, pe.lineno-2), pe.col)
+            msg = str(pe)
+            first_bracket = msg.find("(")
+            if first_bracket != -1:
+                msg = msg[:first_bracket].strip()
+
+            return Diagnostic(
+                range=Range(start, end),
+                message=msg,
+                source="cmake-ls",
+                severity=DiagnosticSeverity.Error,
+            )
+
+
+def main(args: List[str] = None):
+    from argparse import ArgumentParser
+    from pathlib import Path
+
+    parser = ArgumentParser(description="Parse CMake list files")
+    parser.add_argument("lists", type=Path, nargs="*", help="CMake list files")
+    args = parser.parse_args(args)
+
+    list_parser = CMakeListsParser()
+    if not args.lists:
+        return
+
+    for listpath in args.lists:
+        with listpath.open() as fp:
+            content = fp.read()
+
+        results = list_parser.ast_parser.parseString(content, parseAll=True)
+        results.pprint()
+
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1:])

--- a/src/cmake_language_server/server.py
+++ b/src/cmake_language_server/server.py
@@ -9,9 +9,9 @@ from pygls.features import (
     HOVER,
     INITIALIZE,
     INITIALIZED,
-    TEXT_DOCUMENT_DID_SAVE,
+    TEXT_DOCUMENT_DID_CHANGE,
     TEXT_DOCUMENT_DID_OPEN,
-    TEXT_DOCUMENT_DID_CHANGE
+    TEXT_DOCUMENT_DID_SAVE,
 )
 from pygls.server import LanguageServer
 from pygls.types import (
@@ -33,9 +33,9 @@ from pygls.types import (
 )
 
 from .api import API
+from .diagnostics import diagnose
 from .formatter import Formatter
 from .parser import CMakeListsParser
-from .diagnostics import diagnose
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -3,12 +3,12 @@ from contextlib import contextmanager
 from io import StringIO
 
 from cmake_language_server.formatter import Formatter, main
-from cmake_language_server.parser import ListParser
+from cmake_language_server.parser import CMakeListsParser
 
 
 def make_formatter_test(liststr: str, expect: str):
     def test():
-        tokens, remain = ListParser().parse(liststr)
+        tokens, remain = CMakeListsParser().parse_tokens(liststr)
         actual = Formatter().format(tokens)
         assert actual == expect
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,13 +1,13 @@
 from typing import List
 
-from cmake_language_server.parser import ListParser, TokenType
+from cmake_language_server.parser import CMakeListsParser, TokenType
 
 
 def make_parser_test(
     liststr: str, expect_token: List[TokenType], expect_remain: str = ""
 ):
     def test():
-        actual_token, actual_remain = ListParser().parse(liststr)
+        actual_token, actual_remain = CMakeListsParser().parse_tokens(liststr)
         assert actual_token == expect_token
         assert actual_remain == expect_remain
 


### PR DESCRIPTION
This is kind of a big PR, but I hope you'll find it worth your while.

This introduces basic AST parsing on the basis of the grammar you wrote. I made a duplicate grammar that
- suppresses all the whitespace and comments
- distinguish control flow (conditionals, loops, function/macro declarations) from regular command invocations
- adds block-level expectation parsing (opening a `function` implies there must be an `endfunction` somewhere)
- adds semantic actions to generate AST nodes

The cool thing about the expectation parsing (using the `-` instead of `+`) is that it can get you get an exception if you forget to close a block, which can be easily converted into a diagnostic!

Adds `TEXT_DOCUMENT_DID_OPEN`/`_SAVE` features to the language server, which parses the file into an AST and generates diagnostics for single list file only. If the AST parsing was successful, it gets traversed by a bunch of diagnostic-generating visitors much in the style of python's AST module (i.e. if the visitor has a `visit_<ASTNode-type-name>` method matching the type of the node being visited, that function gets called).

I've only added the following diagnostics, whose logic may or may not be flawed at this point:
- `break()` or `continue()` not enclosed in a loop
- `return()` in a macro (suggest replacement with `message(FATAL_ERROR ...)`)
- redundant assignment: `set(asdf ${asdf})` (Yeah, I got bit by this recently :grimacing:)
- duplicate branch in `if/elseif`
- all-uppercase commands (suggest lowercase)
- directory-based api (suggest replacement with target-based api)

Naturally, these are all up for discussion or omission. They're kind of a starter list, since I bet there's a bunch more helpful diagnostics that could be implemented. But maybe we should decide on the general structure for them first, hence this PR.

I also messed around a little in the rest of the files. Fixed a few misspellings and added documentation in some places when I was first trying to find my way around the code.