### PR TITLE
Fixed build system requirements in pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ cmake-format = "cmake_language_server.formatter:main"
 cmake-language-server = "cmake_language_server.server:main"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Poetry depends on lot of dependencies having nothing common with building packages. That's why `poetry-core` was created, which has much less dependencies and more focused on building wheels.