### PR TITLE
poetry: update pygls to version 0.11.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -312,7 +312,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygls"
-version = "0.10.3"
+version = "0.11.2"
 description = "a pythonic generic language server (pronounced like \"pie glass\")."
 category = "main"
 optional = false
@@ -323,9 +323,10 @@ pydantic = ">=1.7,<1.9"
 typeguard = ">=2.10.0,<3"
 
 [package.extras]
-dev = ["bandit (==1.6.0)", "flake8 (==3.7.7)", "mypy (==0.761)"]
+dev = ["bandit (==1.6.0)", "flake8 (==3.7.7)", "mypy (==0.812)"]
 docs = ["sphinx (==2.0.1)", "sphinx-rtd-theme (==0.4.3)"]
 test = ["mock (==3.0.5)", "pytest (==4.5.0)", "pytest-asyncio (==0.10.0)"]
+ws = ["websockets (>=9.0.0,<10.0.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -491,7 +492,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "4b4997f8205fd5dc9bdcc5e7c939b2c5719812cd8671552f6a795d97e5e5d19c"
+content-hash = "414f3daec940f4ed8b9b0c55763ba8ed2350e5ec44de4fdd0722ef36be176b69"
 
 [metadata.files]
 appdirs = [
@@ -684,8 +685,8 @@ pyflakes = [
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygls = [
-    {file = "pygls-0.10.3-py3-none-any.whl", hash = "sha256:055281413d303a816374a51956d94c8554c32f8a499265aac41b0bd5c124bb68"},
-    {file = "pygls-0.10.3.tar.gz", hash = "sha256:522c1068dd38c4945925ca742daba6aff5621168e0e5ddd954813e8b957ca831"},
+    {file = "pygls-0.11.2-py3-none-any.whl", hash = "sha256:5c5b1c8717a39b97462b197f6186c12d2e16455da00631cdaaca91d25736ffcd"},
+    {file = "pygls-0.11.2.tar.gz", hash = "sha256:1ade26fc9cf0d7c0700fa5430e8dc8411b1108d1eb21565adbe480b64f721a84"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cmake-language-server"
-version = "0.1.2"
+version = "0.1.3"
 description = "CMake LSP Implementation"
 license = "MIT"
 authors = ["regen"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-pygls = "^0.10"
+pygls = "^0.11"
 pyparsing = "^2.4"
 importlib-metadata = {version = "^4.8", python = "<3.8"}
 


### PR DESCRIPTION
Update pygls to version 0.11.2 and change the version requirement to
'^0.11' this removes a conflict with jedi-language-server which requires
[pygls>=0.11.1,<0.12.0](https://github.com/pappasam/jedi-language-server/blob/41fe68a319dff3acd27bad0709ffb3b8b11c92a1/pyproject.toml#L45).

This commit also bumps the cmake-language-server version to 0.1.3.