### PR TITLE
Fix parse_modules

### DIFF
--- a/src/cmake_language_server/api.py
+++ b/src/cmake_language_server/api.py
@@ -306,7 +306,7 @@ endforeach()
 (?P<module>.+)\n
 -+\n+?
 (?:(?P<header>\w[\w\s]+)\n\^+\n+?)?
-(?P<doc>.(?:.|\n)+?\n\n)
+(?P<doc>(?:.|\n)*?\n\n)
 """,
             p.stdout + "\n\n",
             re.VERBOSE,


### PR DESCRIPTION
The document of `UseJavaSymlinks` is empty. This PR allows empty documents.