### PR TITLE
Remove cmake-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alpha Stage, work in progress.
 ## Commands
 
 - `cmake-language-server`: LSP server
-- `cmake-format`: CLI frontend for formatting
+- `python -m cmake_language_server.formatter`: CLI frontend for formatting
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ pytest-datadir = "^1.3"
 pytest-cov = "^2.11"
 
 [tool.poetry.scripts]
-cmake-format = "cmake_language_server.formatter:main"
 cmake-language-server = "cmake_language_server.server:main"
 
 [build-system]

--- a/src/cmake_language_server/formatter.py
+++ b/src/cmake_language_server/formatter.py
@@ -154,3 +154,7 @@ def main(argss: Optional[List[str]] = None) -> None:
             print(diffstr, end="")
         else:
             print(formatted, end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR resolves `cmake-format` command conflict with `cmakelang`.

The LSP format function will be replaced by `cmakelang`'s formatter in a future version.