### PR TITLE
Update deprecated actions and environments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@main
     - name: Set up Python 3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, windows-2019]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Setup VC
@@ -41,7 +41,7 @@ jobs:
         env:
           os: ${{ matrix.os }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}


### PR DESCRIPTION
Some actions issue warnings regarding [NodeJS 12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and [Ubuntu 18.04 is deprecated](https://github.com/actions/runner-images/issues/6002) too.

This PR updates all of these.