### PR TITLE
Add Python 3.12 build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04, windows-2022]
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04, windows-2022]
     steps:
       - name: Checkout

--- a/pdm.lock
+++ b/pdm.lock
@@ -549,12 +549,12 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.9.0"
 requires_python = ">=3.7"
 summary = "Backported and Experimental Type Hints for Python 3.7+"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
+    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "pygls>=1.1.1",
 ]
-requires-python = ">=3.7.9,<3.12"
+requires-python = ">=3.7.9,<3.13"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = ["cmake", "completion", "vim", "lsp"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "pygls>=1.1.1",
 ]
-requires-python = ">=3.7.9,<3.13"
+requires-python = ">=3.8.0,<3.13"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = ["cmake", "completion", "vim", "lsp"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{37,38,39,310,311}
+env_list = py{37,38,39,310,311,312}
 isolated_build = True
 passenv = *
 setenv =
@@ -12,6 +12,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{37,38,39,310,311,312}
+env_list = py{38,39,310,311,312}
 isolated_build = True
 passenv = *
 setenv =
@@ -7,7 +7,6 @@ setenv =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
First steps to support to support Python 3.12.

There's a build failure on Ubuntu though:

```
   Traceback (most recent call last):
    File "/home/runner/work/cmake-language-server/cmake-language-server/.tox/py312/bin/mypy", line 5, in <module>
      from mypy.__main__ import console_entry
    File "/home/runner/work/cmake-language-server/cmake-language-server/.tox/py312/lib/python3.12/site-packages/mypy/__main__.py", line 9, in <module>
      from mypy.main import main, process_options
    File "/home/runner/work/cmake-language-server/cmake-language-server/.tox/py312/lib/python3.12/site-packages/mypy/main.py", line 12, in <module>
      from typing_extensions import Final
    File "/home/runner/work/cmake-language-server/cmake-language-server/.tox/py312/lib/python3.12/site-packages/typing_extensions.py", line 1167, in <module>
      class TypeVar(typing.TypeVar, _DefaultMixin, _root=True):
  TypeError: type 'typing.TypeVar' is not an acceptable base type
```