### PR TITLE
Reply with MarkupContent in completion documentation

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,6 +19,7 @@ from lsprotocol.types import (
     FormattingOptions,
     HoverParams,
     InitializeParams,
+    MarkupContent,
     Position,
     TextDocumentIdentifier,
     TextDocumentItem,
@@ -105,8 +106,8 @@ def test_completions(
     response = _test_completion(client_server, datadir, "projec", context)
     item = next(filter(lambda x: x.label == "project", response.items), None)
     assert item is not None
-    assert isinstance(item.documentation, str)
-    assert "<PROJECT-NAME>" in item.documentation
+    assert isinstance(item.documentation, MarkupContent)
+    assert "<PROJECT-NAME>" in item.documentation.value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This changes the type of the documentation in completion items from `str` to `MarkupContent`. This allows clients to render the documentation correctly.

Basically the completion item docs render the same as the hover content now:

![image](https://github.com/regen100/cmake-language-server/assets/2431823/391db808-3b65-49ee-9487-9613ebf9b342)

Before this change, the completion docs rendered as follows:

![image](https://github.com/regen100/cmake-language-server/assets/2431823/96799cc7-247b-4cf3-bcf6-0e8986acec4f)
