### PR TITLE
Remove EOL Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-22.04, windows-2022]
     steps:
       - name: Checkout

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{38,39,310,311,312}
+env_list = py{39,310,311,312}
 isolated_build = True
 passenv = *
 setenv =
@@ -7,7 +7,6 @@ setenv =
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
Python 3.8 is EOL since 2024-10-07.