### PR TITLE
support python 3.13.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "pygls>=1.1.1",
 ]
-requires-python = ">=3.8.0,<=3.13"
+requires-python = ">=3.8.0,<3.14"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = ["cmake", "completion", "vim", "lsp"]


### PR DESCRIPTION
Fixes `error="Failed to find a python3 installation in PATH that meets the required versions (<3.13,>=3.8.0). Found version: 3.13.1."` traceback.