### PR TITLE
Solving new installation import statement with pygls 2.0.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Regen"},
 ]
 dependencies = [
-    "pygls>=1.1.1",
+    "pygls>=1.1.1, <2.0.0",
 ]
 requires-python = ">=3.8.0,<3.14"
 readme = "README.md"


### PR DESCRIPTION
`pygls` just released a new version 4 day ago, and it breaks the imports of cmake-language-server for new installation. Without beeing familiar with both code bases, I cannot vet for further breaking changes with this new version.

However adding up this safe-guard allows for the current codebase to work as previously without any other configuration.

Solves #101 