### PR TITLE
repair bugs LanguageServer not found ,because of pygls changed

### DIFF
--- a/cmake_language_server/server.py
+++ b/cmake_language_server/server.py
@@ -31,7 +31,7 @@ from lsprotocol.types import (
     TextDocumentPositionParams,
     TextEdit,
 )
-from pygls.server import LanguageServer
+from pygls.lsp.server import LanguageServer
 
 from .api import API
 


### PR DESCRIPTION
Due to the recent updates of pygls,the position of LanguageServer has been moved to pygls.lsp.LanguageServer.I hope for a direct upgrade to prepare for future updates.